### PR TITLE
ci: fix swap allocation failing with "Text file busy"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,13 @@ jobs:
 
       - name: Add Swap
         run: |
-          sudo fallocate -l 8G /swapfile
+          # GitHub-hosted runners ship with an active swap file, so fallocate
+          # on /swapfile fails with "Text file busy" (ETXTBSY). Disable and
+          # remove any existing swap first, then build a fresh swap file with
+          # dd (the kernel-recommended method that avoids holes/ETXTBSY).
+          sudo swapoff -a || true
+          sudo rm -f /swapfile
+          sudo dd if=/dev/zero of=/swapfile bs=1M count=8192 status=progress
           sudo chmod 600 /swapfile
           sudo mkswap /swapfile
           sudo swapon /swapfile


### PR DESCRIPTION
## Problem

The **Add Swap** step in `.github/workflows/build.yml` failed:

```
fallocate: fallocate failed: Text file busy
##[error]Process completed with exit code 1.
```

GitHub-hosted `ubuntu-latest` runners already ship with an **active swap file**. `fallocate` refuses to (re)size a file that is currently in use as swap, returning `ETXTBSY` → `Text file busy`.

## Fix

In the `Add Swap` step:

1. `sudo swapoff -a` — release any swap the runner already has active.
2. `sudo rm -f /swapfile` — remove the pre-existing busy file.
3. Create the swap file with `dd` instead of `fallocate`.

Using `dd` is the kernel-recommended way to create swap files: `fallocate`'d files can contain sparse holes that `swapon` rejects (`swapon: skipping - it appears to have holes`), and it sidesteps the `ETXTBSY` entirely.

```yaml
- name: Add Swap
  run: |
    sudo swapoff -a || true
    sudo rm -f /swapfile
    sudo dd if=/dev/zero of=/swapfile bs=1M count=8192 status=progress
    sudo chmod 600 /swapfile
    sudo mkswap /swapfile
    sudo swapon /swapfile
    free -h
```

Net effect is the same 8 GiB swap file, created reliably.

> Targets `develop` since that is the branch carrying the `Add Swap` step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VZLQbvTp7QKoLag89DxYjv)_